### PR TITLE
UI: Tournament overview page with location map

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import BadgesPage from "pages/BadgesPage";
 import UsersPage from "pages/UsersPage";
 import AllTournamentsPage from "pages/AllTournamentsPage";
 import TournamentEditPage, {TournamentCreatePage} from "pages/TournamentEditPage";
+import TournamentOverviewPage from "pages/TournamentPage/TournamentOverviewPage";
 import BadgePage from "pages/BadgePage";
 import UserProfileEditPage from "pages/UserProfileEditPage";
 import {AuthenticatedUserContextProvider} from "contexts/AuthenticatedUserContext";
@@ -43,9 +44,10 @@ function App() {
                                 <Route element={<DefaultLayout/>}>
                                     <Route path="/" element={<MainPage/>}/>
                                     <Route path="/about" element={<AboutPage/>}/>
-                                    <Route path="/tournament/:id" element={<TournamentPage/>}/>
+                                    <Route path="/tournament/:id" element={<TournamentOverviewPage/>}/>
+                                    <Route path="/tournament/:id/pairings" element={<TournamentPage/>}/>
+                                    <Route path="/tournament/:id/pairings/round/:roundId" element={<TournamentPage/>}/>
                                     <Route path="/event/:city/:date" element={<EventPage/>}/>
-                                    <Route path="/tournament/:id/round/:roundId" element={<TournamentPage />}/>
                                     <Route path="/tournament/:tournamentId/participant/:participantId"
                                            element={<ParticipantPage/>}/>
                                     <Route path="/tournament/:tournamentId/edit"

--- a/frontend/src/pages/MainPage/MyActiveTournamentPane.tsx
+++ b/frontend/src/pages/MainPage/MyActiveTournamentPane.tsx
@@ -241,7 +241,7 @@ function MyActiveTournamentPaneImpl(
     return <div className={`grid justify-items-start w-full p-4 overflow-hidden tournament-active`}>
         <div className={"grid w-full justify-items-start"}>
             <Link className={"flex w-full gap-2 text-lg text-left justify-between items-center"}
-                  to={`/tournament/${tournament.id}/round/${roundNumber}`}
+                  to={`/tournament/${tournament.id}/pairings/round/${roundNumber}`}
             >
                 <div className="flex gap-2 hover:underline font-semibold">
                     <span className={"grow"}>

--- a/frontend/src/pages/MainPage/TournamentPane.tsx
+++ b/frontend/src/pages/MainPage/TournamentPane.tsx
@@ -5,12 +5,10 @@ import {useMemo} from "react";
 import {Link} from "react-router-dom";
 import {BsBookmarkCheckFill, BsFillRecordFill} from "react-icons/bs";
 import dayjs from "dayjs";
-import {Conditional, ConditionalOnAuthorized} from "components/Conditional";
+import {Conditional} from "components/Conditional";
 import {AiFillClockCircle} from "react-icons/ai";
 import {IoLocationSharp} from "react-icons/io5";
-import tournamentRepository from "lib/api/repository/TournamentRepository";
 import participantRepository from "lib/api/repository/ParticipantRepository";
-import useLoginPageLink from "lib/react/hooks/useLoginPageLink";
 import {FaUserCheck, FaUsers} from "react-icons/fa6";
 
 export function TournamentPane(
@@ -21,7 +19,6 @@ export function TournamentPane(
     }
 ) {
     let loc = useLoc();
-    let loginPageLink = useLoginPageLink();
 
     let winnerQuery = useQuery({
         queryKey: ["tournamentWinner", tournament.id],
@@ -145,39 +142,9 @@ export function TournamentPane(
         </Conditional>
         <div className={"p-1"}></div>
         <Conditional on={isPlanned}>
-            <div className={"w-full flex"}>
-                <ConditionalOnAuthorized>{() =>
-                    !isMeParticipating ? (
-                        <button className={"btn-primary w-full uppercase"}
-                                onClick={async () => {
-                                    let nickname = window.prompt("Please enter your nickname");
-                                    if (!nickname) {
-                                        alert("Nickname is not provided. Registration is cancelled.")
-                                    } else {
-                                        await tournamentRepository.participate(tournament.id, nickname)
-                                            .catch(() => alert("Could not participate in tournament"));
-                                        await meParticipantQuery.refetch()
-                                    }
-                                }}
-                        >
-                            {loc("Participate")}
-                        </button>
-                    ) : (
-                        <Link className={"btn-primary w-full uppercase"} to={`/tournament/${tournament.id}`}>
-                            {loc("Open")}
-                        </Link>
-                    )
-                }
-                </ConditionalOnAuthorized>
-                <ConditionalOnAuthorized authorized={false}>{() =>
-                    <Link to={loginPageLink} className={"w-full"}>
-                        <button className={"btn-primary w-full uppercase"}>
-                            {loc("Participate")}
-                        </button>
-                    </Link>
-                }
-                </ConditionalOnAuthorized>
-            </div>
+            <Link className={"btn-primary w-full uppercase"} to={`/tournament/${tournament.id}`}>
+                {loc("Open")}
+            </Link>
         </Conditional>
         <Conditional on={isActive}>
             <Link className={"btn-primary w-full uppercase"}

--- a/frontend/src/pages/TournamentPage/TournamentLocationMap.tsx
+++ b/frontend/src/pages/TournamentPage/TournamentLocationMap.tsx
@@ -1,0 +1,23 @@
+const CITY_MAP_EMBED_URLS: Record<string, string> = {
+    limassol: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d205.07519633715472!2d33.047921464833614!3d34.67482215483466!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x14e733ac485738eb%3A0x2bf26bab8beb81a7!2sChess%20Grinder!5e0!3m2!1sen!2s!4v1777202322478!5m2!1sen!2s",
+    berlin: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2187.651783795628!2d13.408156497275556!3d52.527073439803885!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47a84fb3e5360885%3A0x77845dd97dd0242f!2sChess%20Grinder!5e0!3m2!1sen!2s!4v1777202818486!5m2!1sen!2s",
+    tbilisi: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5958.753933972758!2d44.793516093579115!3d41.69079720000002!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x40440d4a13bc1a3f%3A0x36b77d13f1282a5a!2sSecret%20lounge!5e0!3m2!1sen!2s!4v1777202908448!5m2!1sen!2s",
+};
+
+export default function TournamentLocationMap({city}: {city?: string | null}) {
+    if (!city) return null;
+    const src = CITY_MAP_EMBED_URLS[city.trim().toLowerCase()];
+    if (!src) return null;
+    return (
+        <div className={"w-full aspect-[4/3] sm:aspect-[16/9] max-h-[450px]"}>
+            <iframe
+                title={`${city} location`}
+                src={src}
+                className={"w-full h-full border-0"}
+                allowFullScreen
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+            />
+        </div>
+    );
+}

--- a/frontend/src/pages/TournamentPage/TournamentOverviewPage.tsx
+++ b/frontend/src/pages/TournamentPage/TournamentOverviewPage.tsx
@@ -1,0 +1,150 @@
+import {Link, useNavigate, useParams} from "react-router-dom";
+import {useQuery} from "@tanstack/react-query";
+import dayjs from "dayjs";
+import tournamentPageRepository from "lib/api/repository/TournamentPageRepository";
+import tournamentRepository from "lib/api/repository/TournamentRepository";
+import participantRepository from "lib/api/repository/ParticipantRepository";
+import {TournamentPageData} from "lib/api/dto/TournamentPageData";
+import {DEFAULT_DATETIME_FORMAT} from "lib/api/dto/MainPageData";
+import {Conditional} from "components/Conditional";
+import {useAuthenticatedUser} from "contexts/AuthenticatedUserContext";
+import useLoginPageLink from "lib/react/hooks/useLoginPageLink";
+import {useLoc} from "strings/loc";
+import {usePageTitle} from "lib/react/hooks/usePageTitle";
+import TournamentLocationMap from "pages/TournamentPage/TournamentLocationMap";
+import {IconTag} from "pages/MainPage/TournamentPane";
+import {AiFillClockCircle} from "react-icons/ai";
+import {IoLocationSharp} from "react-icons/io5";
+import {FaUserCheck, FaUsers} from "react-icons/fa6";
+import {BsFillRecordFill} from "react-icons/bs";
+import {GiChessKnight} from "react-icons/gi";
+import {MdEvent} from "react-icons/md";
+
+export default function TournamentOverviewPage() {
+    const {id} = useParams();
+    const loc = useLoc();
+    const navigate = useNavigate();
+    const loginPageLink = useLoginPageLink();
+    const [authenticatedUser] = useAuthenticatedUser();
+    const isAuthenticatedUser = !!authenticatedUser;
+
+    const tournamentQuery = useQuery({
+        queryKey: ["tournamentPageData", id],
+        queryFn: () => id ? tournamentPageRepository.getData(id) : Promise.reject<TournamentPageData>(new Error()),
+    });
+
+    const meParticipantQuery = useQuery({
+        queryKey: ["meParticipant", id],
+        queryFn: async () => id == null ? null : await participantRepository.getMe(id).catch(() => null),
+    });
+
+    const tournament = tournamentQuery.data?.tournament;
+
+    usePageTitle(`${tournament?.name || "Unnamed"} - ${tournament?.date ? dayjs(tournament.date, DEFAULT_DATETIME_FORMAT).format("DD.MM.YYYY") : ""} - Tournament - ChessGrinder`, [tournamentQuery.data]);
+
+    if (!id) return <>No tournament id!</>;
+    if (tournamentQuery.isLoading) return <>Loading...</>;
+    if (tournamentQuery.isError || !tournament) return <>Error! tid: {id}</>;
+
+    const hideParticipateButton = !meParticipantQuery.isSuccess || !!meParticipantQuery.data;
+    const isMeParticipating = !!meParticipantQuery?.data?.id && !meParticipantQuery?.data?.isMissing;
+
+    async function participate() {
+        const nickname = window.prompt("Please enter your nickname");
+        if (!nickname) {
+            alert("Nickname is not provided. Registration is cancelled.");
+            return;
+        }
+        await tournamentRepository.participate(tournament!.id, nickname)
+            .catch(() => alert("Could not participate in tournament"));
+        await meParticipantQuery.refetch();
+        await tournamentQuery.refetch();
+    }
+
+    async function leaveTournament() {
+        if (!window.confirm("You want to be removed from the tournament?")) {
+            alert("You stay in the tournament.");
+            return;
+        }
+        await participantRepository.missMe(tournament!.id)
+            .catch(() => alert("Could not withdraw from tournament"));
+        await meParticipantQuery.refetch();
+        await tournamentQuery.refetch();
+    }
+
+    const participantsCount = tournamentQuery.data?.participants?.length ?? null;
+
+    return <>
+        <div className={"flex mt-4 p-2 items-center content-center"}>
+            <h2 className={"text-lg font-semibold text-left grow flex items-center gap-2"}>
+                <span>{tournament.name || loc(`Unnamed Tournament`)}</span>
+                <Conditional on={tournament.status === "ACTIVE"}>
+                    <span className={"text-red-500"}><BsFillRecordFill/></span>
+                </Conditional>
+            </h2>
+            <div className={"px-2 text-right"}>
+                <div><small className={"font-semibold text-gray-500"}>{tournament.status}</small></div>
+                <div><span className={"font-semibold"}>{tournament.date && dayjs(tournament.date).format("DD.MM.YY")}</span></div>
+            </div>
+        </div>
+
+        <div className={"p-2 grid gap-2 text-left"}>
+            <IconTag
+                icon={<MdEvent className={"text-primary-400"}/>}
+                text={tournament.date ? dayjs(tournament.date, DEFAULT_DATETIME_FORMAT).format("DD.MM.YYYY") : "—"}
+            />
+            <IconTag
+                icon={<AiFillClockCircle className={"text-primary-400"}/>}
+                text={tournament.date ? dayjs(tournament.date, DEFAULT_DATETIME_FORMAT).format("HH:mm") : "—"}
+            />
+            {(tournament.city || tournament.locationName) && (
+                <IconTag
+                    icon={<IoLocationSharp className={"text-primary-400"}/>}
+                    text={[tournament.locationName, tournament.city].filter(Boolean).join(", ")}
+                    link={tournament.locationUrl || undefined}
+                />
+            )}
+            {!!tournament.roundsNumber && (
+                <IconTag
+                    icon={<GiChessKnight className={"text-primary-400"}/>}
+                    text={`${tournament.roundsNumber} ${loc("rounds")}`}
+                />
+            )}
+            <Conditional on={participantsCount != null}>
+                <IconTag
+                    icon={<FaUsers className={"text-primary-400"}/>}
+                    text={<span>{participantsCount}{!!tournament.registrationLimit ?
+                        <small>/{tournament.registrationLimit}</small> : null}</span>}
+                />
+            </Conditional>
+            <Conditional on={isMeParticipating}>
+                <IconTag
+                    icon={<FaUserCheck className={"text-primary-400"}/>}
+                    text={loc("Participating")}
+                />
+            </Conditional>
+        </div>
+
+        <div className={"px-2 grid gap-2"}>
+            <Conditional on={!hideParticipateButton && tournament.status === "PLANNED"}>
+                {isAuthenticatedUser
+                    ? <button className={"btn-primary w-full uppercase"} onClick={participate}>{loc("Participate")}</button>
+                    : <Link to={loginPageLink} className={"w-full"}>
+                        <button className={"btn-primary w-full uppercase"}>{loc("Participate")}</button>
+                    </Link>}
+            </Conditional>
+            <Conditional on={isAuthenticatedUser && isMeParticipating && tournament.status !== "FINISHED"}>
+                <button className={"btn-light uppercase w-full"} onClick={leaveTournament}>
+                    {loc("Leave the tournament")}
+                </button>
+            </Conditional>
+            <button className={"btn-primary w-full uppercase"} onClick={() => navigate(`/tournament/${id}/pairings`)}>
+                {loc("Pairings")}
+            </button>
+        </div>
+
+        <div className={"p-2"}>
+            <TournamentLocationMap city={tournament.city}/>
+        </div>
+    </>;
+}

--- a/frontend/src/pages/TournamentPage/index.tsx
+++ b/frontend/src/pages/TournamentPage/index.tsx
@@ -14,7 +14,6 @@ import dayjs from "dayjs";
 import roundRepository from "lib/api/repository/RoundRepository";
 import AddParticipantTournamentPageSection from "pages/TournamentPage/AddParticipantTournamentPageSection";
 import {useAuthenticatedUser} from "contexts/AuthenticatedUserContext";
-import useLoginPageLink from "lib/react/hooks/useLoginPageLink";
 import MyActiveTournamentPane from "pages/MainPage/MyActiveTournamentPane";
 import restApiClient from "lib/api/RestApiClient";
 import {usePageTitle} from "lib/react/hooks/usePageTitle";
@@ -52,7 +51,6 @@ export function TournamentPageImpl(
     }) {
     let loc = useLoc()
     let id = tournament.id;
-    let loginPageLink = useLoginPageLink();
     let tournamentQuery = useQuery({
         queryKey: ["tournamentPageData", id],
         queryFn: () => id ? tournamentPageRepository.getData(id) : Promise.reject<TournamentPageData>(new Error())
@@ -99,7 +97,7 @@ export function TournamentPageImpl(
         try {
             await roundRepository.postRound(id)
             await tournamentQuery.refetch();
-            let newRoundSubPath = tournamentData && tournamentData.rounds ? `/round/${tournamentData.rounds.length + 1}` : "";
+            let newRoundSubPath = tournamentData && tournamentData.rounds ? `/pairings/round/${tournamentData.rounds.length + 1}` : "/pairings";
             navigate(`/tournament/${id}${newRoundSubPath}`, {replace: true});
         } catch (e: any) {
             alert("Could not create round. " +
@@ -148,7 +146,6 @@ export function TournamentPageImpl(
         await restApiClient.post(`/nickname-contest/${tournament.id}`);
     }
 
-    let hideParticipateButton = !meParticipantQuery.isSuccess || !!meParticipantQuery.data
     let isTournamentFinished = tournament.status === "FINISHED"
 
     async function startTournament() {
@@ -178,29 +175,6 @@ export function TournamentPageImpl(
         navigate("/");
     }
 
-    async function participate() {
-        let nickname = window.prompt("Please enter your nickname");
-        if (!nickname) {
-            alert("Nickname is not provided. Registration is cancelled.")
-        } else {
-            await tournamentRepository.participate(tournament.id, nickname)
-                .catch(() => alert("Could not participate in tournament"));
-            await meParticipantQuery.refetch()
-            await tournamentQuery.refetch()
-        }
-    }
-
-    async function leaveTournament() {
-        if (!window.confirm("You want to be removed from the tournament?")) {
-            alert("You stay in the tournament.")
-        } else {
-            await participantRepository.missMe(tournament.id)
-                .catch(() => alert(`Could not withdraw from tournament`));
-            await meParticipantQuery.refetch()
-            await tournamentQuery.refetch()
-        }
-    }
-
     return <>
         <div className={"flex mt-4 p-2 items-top content-center"}>
             <h2 className={"text-lg font-semibold text-left grow"}>
@@ -221,24 +195,6 @@ export function TournamentPageImpl(
         <div className={"p-2"}>
             <NicknameContextPane tournamentId={tournament.id}/>
         </div>
-        {!hideParticipateButton && tournament.status === "PLANNED" && (
-            <div className={"px-2"}>
-                {isAuthenticatedUser ?
-                    (
-                        <button className={"btn-primary w-full uppercase"} onClick={participate}>
-                            {loc("Participate")}
-                        </button>
-                    ) : (
-                        <Link to={loginPageLink} className={"w-full"}>
-                            <button className={"btn-primary w-full uppercase"}>
-                                {loc("Participate")}
-                            </button>
-                        </Link>
-                    )
-                }
-            </div>
-        )}
-
         <Conditional on={isMeModerator}>
             <Conditional on={tournament.status !== "FINISHED"}>
                 <AddParticipantTournamentPageSection participants={participants} addParticipant={addParticipant}/>
@@ -246,7 +202,7 @@ export function TournamentPageImpl(
         </Conditional>
 
         <div className={"flex flex-wrap text-sm justify-start place-items-stretch w-full px-2 my-4"}>
-            <Link className={"lg:col-span-1"} to={`/tournament/${id}`} replace={true}>
+            <Link className={"lg:col-span-1"} to={`/tournament/${id}/pairings`} replace={true}>
                 <button
                     className={`w-full h-full py-1 px-3 border border-black uppercase ${isMain ? "bg-primary-400 text-white" : "hover:bg-gray-300 text-black"}`}
                     title={loc("Tournament page")}
@@ -256,7 +212,7 @@ export function TournamentPageImpl(
             </Link>
             {roundNumbers.map(rid => {
                 return <Link
-                    to={`/tournament/${id}/round/${rid}`} title={loc(`Open round`) + " " + rid}
+                    to={`/tournament/${id}/pairings/round/${rid}`} title={loc(`Open round`) + " " + rid}
                     key={rid}
                     replace={!!roundId} // Write history only if navigating from home page
                 >
@@ -297,21 +253,6 @@ export function TournamentPageImpl(
                 </div>
             </Conditional>
         </>
-        <Conditional on={isMain}>
-            <Conditional on={isAuthenticatedUser && !!meParticipantQuery.data && !meParticipantQuery.data?.isMissing}>
-                <Conditional on={!isTournamentFinished}>
-                    <div className={"grid 2-full p-2"}>
-                        <button
-                            className={"btn-light uppercase w-full"}
-                            onClick={leaveTournament}
-                            title={loc("Leave the tournament")}
-                        >
-                            {loc("Leave the tournament")}
-                        </button>
-                    </div>
-                </Conditional>
-            </Conditional>
-        </Conditional>
         <Conditional on={isMain && isMeModerator}>
             <ControlButtons
                 startNicknameContest={startNicknameContest}


### PR DESCRIPTION
Split /tournament/:id into a slim overview (header, info, participate, pairings link, embedded city map) and move the existing rounds/results view to /tournament/:id/pairings. Migrate the remaining round-link callers (MyActiveTournamentPane "Game N", createRound navigation) to the /pairings/round/:roundId path and drop the legacy
/tournament/:id/round/:roundId route. The map is rendered for known cities (Limassol, Berlin, Tbilisi) via lazy-loaded Google Maps embed.